### PR TITLE
Emacs 28+ required to enable ligatures

### DIFF
--- a/layers/+fonts/unicode-fonts/README.org
+++ b/layers/+fonts/unicode-fonts/README.org
@@ -17,7 +17,7 @@ install the fonts listed in the [[https://github.com/rolandwalker/unicode-fonts#
 - Easily override glyphs or sections of glyphs.
 - Display color emoji on both the macOS port version of Emacs and emacs-plus (with
   =unicode-fonts-force-multi-color-on-mac= set to non nil).
-- Enable support for font ligature in Emacs 27 + via [[https://github.com/mickeynp/ligature.el][ligatures.el]].
+- Enable support for font ligature in Emacs 28 + via [[https://github.com/mickeynp/ligature.el][ligatures.el]].
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
From https://github.com/mickeynp/ligature.el#compatibility-and-version-requirements: "You must use Emacs 28 or later, or backport a fix to Emacs 27.x"

Hi, I've updated the requirements in the README stating that Emacs 28+ is required for typographic ligatures